### PR TITLE
Fixes to make things work in Raspbian Jessie

### DIFF
--- a/01_Hello_Triangle.py
+++ b/01_Hello_Triangle.py
@@ -36,7 +36,7 @@ triangle_vertices = eglfloats(( -0.866, -0.5, 1.0,
 opengles.glClear ( GL_COLOR_BUFFER_BIT )
 
 # Set the Viewport: (NB openegl, not opengles)
-openegl.glViewport(0,0,ctx.width, ctx.height)
+opengles.glViewport(0,0,ctx.width, ctx.height)
 
 # Use the program object
 opengles.glUseProgram ( program )

--- a/02_Hello_Rotating_Triangle.py
+++ b/02_Hello_Rotating_Triangle.py
@@ -61,7 +61,7 @@ triangle_vertices = eglfloats(( -0.866, -0.5, 1.0,
 opengles.glUseProgram ( program )
 
 # Set the Viewport: (NB openegl, not opengles)
-openegl.glViewport(0,0,ctx.width, ctx.height)
+opengles.glViewport(0,0,ctx.width, ctx.height)
 
 # Find the location of the 'uniform' rotation:
 rot_loc = opengles.glGetUniformLocation(program, "rotation")

--- a/03_Hello_Moving_Triangle.py
+++ b/03_Hello_Moving_Triangle.py
@@ -74,7 +74,7 @@ triangle_vertices = eglfloats(( -0.866, -0.5, 1.0,
 opengles.glUseProgram ( program )
 
 # Set the Viewport: (NB openegl, not opengles)
-openegl.glViewport(0,0,ctx.width, ctx.height)
+opengles.glViewport(0,0,ctx.width, ctx.height)
 
 # Find the location of the 'uniform' rotation:
 rot_loc = opengles.glGetUniformLocation(program, "rotation")

--- a/04_Hello_Aspect_Ratio.py
+++ b/04_Hello_Aspect_Ratio.py
@@ -85,7 +85,7 @@ triangle_vertices = eglfloats(( -0.866, -0.5, 1.0,
 opengles.glUseProgram ( program )
 
 # Set the Viewport: (NB openegl, not opengles)
-openegl.glViewport(0,0,ctx.width, ctx.height)
+opengles.glViewport(0,0,ctx.width, ctx.height)
 
 # Find the location of the 'uniform' rotation:
 rot_loc = opengles.glGetUniformLocation(program, "rotation")

--- a/env_glsl.py
+++ b/env_glsl.py
@@ -64,7 +64,8 @@ void main( void ) {
 	gl_FragColor = vec4(fract(-log(s)*10.),fract(-log(s)*1.),fract(-log(s)/10.),1.);
 }"""
 
-e = EGL(alpha_flags=1<<16) # fullscreen, RGBA, alpha-PREMULT flag on
+# fullscreen, alpha fixed for all pixels, PREMULT flag on
+e = EGL(alpha_flags=1+1<<16, alpha_opacity=128)
 #e=EGL(pref_width = 640, pref_height=480)
 
 surface_tris = eglfloats( (  - 1.0, - 1.0, 1.0, 

--- a/pyopengles/pyopengles.py
+++ b/pyopengles/pyopengles.py
@@ -177,7 +177,7 @@ class EGL(object):
                                   layer, ctypes.byref(dst_rect), 0,
                                   ctypes.byref(src_rect),
                                   DISPMANX_PROTECTION_NONE,
-                                  alpha_s , 0, 0)
+                                  ctypes.byref(alpha_s) , 0, 0)
         bcm.vc_dispmanx_update_submit_sync( dispman_update )
         nativewindow = eglints((dispman_element,width,height));
         nw_p = ctypes.pointer(nativewindow)


### PR DESCRIPTION
I'm running Raspbian Jessie on a Raspberry Pi 2 B. The 0[1234]_*.py samples couldn't find glViewport, and glsl_sandbox.sh produced no output. This fixes both problems. 

Opacity is set to half. I don't know much about OpenGL and I hope the opacity flags are appropriate. I left the premult flag because it was there before. I also set DISPMANX_FLAGS_ALPHA_FIXED_ALL_PIXELS because that was needed for alpha_opacity to be respected. Despite "fixed all pixels" in the name, if the shader supplies alpha < 1, that is multiplied by alpha_opacity. In other words I can make things more transparent if I decrease the 1. in `gl_FragColor = vec4(c,1.);` in leds.glsl, but I can't make them more opaque by increasing the number to more than 1.
